### PR TITLE
Pin rolldown@1.0.0 in angular-cli/vite-default-ts

### DIFF
--- a/angular-cli/vite-default-ts/after-storybook/package.json
+++ b/angular-cli/vite-default-ts/after-storybook/package.json
@@ -91,6 +91,7 @@
     "@storybook/server": "10.4.0-alpha.17",
     "@storybook/svelte": "10.4.0-alpha.17",
     "@storybook/vue3": "10.4.0-alpha.17",
-    "@storybook/web-components": "10.4.0-alpha.17"
+    "@storybook/web-components": "10.4.0-alpha.17",
+    "rolldown": "1.0.0"
   }
 }


### PR DESCRIPTION
Companion to storybookjs/storybook#34202. Forces single rolldown version so Vite 8's bundled `Visitor` export resolves correctly.